### PR TITLE
Update GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,9 @@ jobs:
         node-version: [22.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci


### PR DESCRIPTION
`actions/checkout@v2` and `actions/setup-node@v2` run on a deprecated Node runtime that warns on every CI run. This bumps both to v5.

No behaviour change: the Node version matrix, the build steps and the Rust toolchain pin are untouched.