### PR TITLE
Use 1.7.0 as the version everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.0.1
+VERSION := 1.7.0
 
 LANGUAGE_NAME := tree-sitter-elisp
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-elisp"
 description = "Elisp grammar for tree-sitter"
-version = "0.0.1"
+version = "1.7.0"
 keywords = ["incremental", "parsing", "tree-sitter", "elisp"]
 classifiers = [
   "Intended Audience :: Developers",


### PR DESCRIPTION
`Cargo.toml`, `package.json` and `tree-sitter.json` are all at 1.7.0, but `pyproject.toml` and the `Makefile` were left at the 0.0.1 placeholder from `tree-sitter init`.

That means Python wheels are published as 0.0.1, and `make install` gives the shared library a `.so.0.0` SONAME instead of `.so.1.7`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017dnQ2Nn7CLMP2gEdRhNyt3)_