### PR TITLE
Point repository URLs at Wilfred/tree-sitter-elisp

### DIFF
--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tree_sitter "github.com/smacker/go-tree-sitter"
-	"github.com/tree-sitter/tree-sitter-elisp"
+	"github.com/Wilfred/tree-sitter-elisp"
 )
 
 func TestCanLoadGrammar(t *testing.T) {

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/tree-sitter/tree-sitter-elisp
+module github.com/Wilfred/tree-sitter-elisp
 
 go 1.22
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ license.text = "MIT"
 readme = "README.md"
 
 [project.urls]
-Homepage = "https://github.com/tree-sitter/tree-sitter-elisp"
+Homepage = "https://github.com/Wilfred/tree-sitter-elisp"
 
 [project.optional-dependencies]
 core = ["tree-sitter~=0.21"]


### PR DESCRIPTION
Three URLs still pointed at `github.com/tree-sitter/tree-sitter-elisp`, which is not where this grammar lives:

- `pyproject.toml` — the homepage shown on PyPI.
- `bindings/go/go.mod` — the Go module path, so `go get github.com/Wilfred/tree-sitter-elisp` could not resolve the package.
- `bindings/go/binding_test.go` — the matching import.

---
_Generated by [Claude Code](https://claude.ai/code/session_017dnQ2Nn7CLMP2gEdRhNyt3)_