### PR TITLE
Regenerate parser.c

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -6455,7 +6455,7 @@ TS_PUBLIC const TSLanguage *tree_sitter_elisp(void) {
     .max_reserved_word_set_size = 0,
     .metadata = {
       .major_version = 1,
-      .minor_version = 6,
+      .minor_version = 7,
       .patch_version = 0,
     },
   };


### PR DESCRIPTION
The committed `src/parser.c` still reported version 1.6.0 in its language metadata, because it was not regenerated when `tree-sitter.json` moved to 1.7.0. Consumers reading `ts_language_metadata` therefore saw the wrong version.

Regenerated with tree-sitter 0.25.10, the version in `package.json`. The only change is the metadata `minor_version`; the parse tables are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_017dnQ2Nn7CLMP2gEdRhNyt3)_