### PR TITLE
Remove the unused dot rule

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -199,8 +199,7 @@ module.exports = grammar({
     unquote_splice: ($) => seq(",@", $._sexp),
     unquote: ($) => seq(",", $._sexp),
 
-    dot: ($) => token("."),
-    list: ($) => seq("(", choice(repeat($._sexp)), ")"),
+    list: ($) => seq("(", repeat($._sexp), ")"),
     vector: ($) => seq("[", repeat($._sexp), "]"),
     bytecode: ($) => seq("#[", repeat($._sexp), "]"),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -720,13 +720,6 @@
         }
       ]
     },
-    "dot": {
-      "type": "TOKEN",
-      "content": {
-        "type": "STRING",
-        "value": "."
-      }
-    },
     "list": {
       "type": "SEQ",
       "members": [
@@ -735,16 +728,11 @@
           "value": "("
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_sexp"
-              }
-            }
-          ]
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_sexp"
+          }
         },
         {
           "type": "STRING",


### PR DESCRIPTION
`dot` was never referenced from any other rule, so it never matched anything — it isn't in `node-types.json`, and dotted pairs like `(a . b)` parse as two symbols with the `.` as a third.

The `list` rule also wrapped its body in a single-branch `choice`, which looks like a leftover from the same unfinished attempt at dotted pairs.

`src/node-types.json` is unchanged after regenerating, which confirms the rule was already unreachable — the only generated change is `src/grammar.json` shrinking.

Rebased onto current main and re-verified there: `tree-sitter generate` produces no further diff, and the corpus and highlight tests pass.

This removes the rule rather than finishing it. Happy to make dotted pairs a real node instead if you'd prefer.