### PR TITLE
Build against Node 24 rather than Node 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,19 +10,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        # Node 24 requires C++ 20, presumably in binding.gyp.
-        #
-        # https://nodejs.org/en/blog/migrations/v22-to-v24#cc-addons
-        node-version: [22.x]
-
     steps:
       - uses: actions/checkout@v5
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 24.x
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test

--- a/binding.gyp
+++ b/binding.gyp
@@ -13,6 +13,22 @@
         "src/parser.c",
         # NOTE: if your language has an external scanner, add it here.
       ],
+      # Node 24 builds addons against V8 headers that need C++ 20.
+      #
+      # https://nodejs.org/en/blog/migrations/v22-to-v24#cc-addons
+      "cflags_cc": [
+        "-std=c++20",
+      ],
+      "xcode_settings": {
+        "CLANG_CXX_LANGUAGE_STANDARD": "c++20",
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": {
+          "AdditionalOptions": [
+            "/std:c++20",
+          ],
+        },
+      },
       "conditions": [
         ["OS!='win'", {
           "cflags_c": [


### PR DESCRIPTION
The CI matrix was pinned to Node 22, with a comment noting that Node 24 would need C++ 20 in `binding.gyp`. This drops the matrix and sets the version unconditionally.

`binding.gyp` set the C standard for `parser.c` but left the C++ standard for `binding.cc` to the node-gyp default, which is what the [v22 to v24 migration notes](https://nodejs.org/en/blog/migrations/v22-to-v24#cc-addons) call out. It is now set explicitly for gcc/clang, Xcode and MSVC.

CI is green on Node 24.

An earlier revision of this branch failed, but inside `node_modules/tree-sitter` rather than in this package — `tree-sitter@0.25.0` ships no prebuilds, so npm compiled it from source against Node 24's V8 headers. That run predated #21; now that `peerDependenciesMeta` names the peer correctly, CI skips the optional `tree-sitter` peer and nothing gets compiled. #24 syncs the lockfile to 0.25.1 so the prebuilds are used when it *is* installed, but this PR no longer depends on it.