### PR TITLE
Fix peer dependency name in peerDependenciesMeta

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "tree-sitter": "^0.25.0"
   },
   "peerDependenciesMeta": {
-    "tree_sitter": {
+    "tree-sitter": {
       "optional": true
     }
   },


### PR DESCRIPTION
The `peerDependenciesMeta` key was `tree_sitter`, but the peer dependency it refers to is `tree-sitter`. npm matches the two by name, so the entry matched nothing and `tree-sitter` was still treated as a required peer dependency rather than an optional one.

---
_Generated by [Claude Code](https://claude.ai/code/session_017dnQ2Nn7CLMP2gEdRhNyt3)_