### PR TITLE
Ship tree-sitter.json in the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "files": [
     "grammar.js",
+    "tree-sitter.json",
     "binding.gyp",
     "prebuilds/**",
     "bindings/node/*",


### PR DESCRIPTION
`tree-sitter.json` holds the grammar metadata the tree-sitter CLI reads — scope, file types, injection regex, highlights path — but it was missing from the `files` list, so npm excluded it from the published tarball. `Cargo.toml` already includes it.

Confirmed with `npm pack --dry-run`: the file now appears in the tarball contents (18 files, up from 17).

---
_Generated by [Claude Code](https://claude.ai/code/session_017dnQ2Nn7CLMP2gEdRhNyt3)_