### PR TITLE
Resolve tree-sitter 0.25.1 in the lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-elisp",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-elisp",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -21,7 +21,7 @@
         "tree-sitter": "^0.25.0"
       },
       "peerDependenciesMeta": {
-        "tree_sitter": {
+        "tree-sitter": {
           "optional": true
         }
       }
@@ -338,14 +338,15 @@
       }
     },
     "node_modules/tree-sitter": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.25.0.tgz",
-      "integrity": "sha512-PGZZzFW63eElZJDe/b/R/LbsjDDYJa5UEjLZJB59RQsMX+fo0j54fqBPn1MGKav/QNa0JR0zBiVaikYDWCj5KQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.25.1.tgz",
+      "integrity": "sha512-mrcEdkYtHfrK1A6fs3O6FxkBo0Qig5XUXqHhxUOQu0bmPo00QF4XaSx4edpazdHwxnSCjlGKGgIqWdaN4dvTLA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
-        "node-addon-api": "^8.3.0",
+        "node-addon-api": "^8.5.0",
         "node-gyp-build": "^4.8.4"
       }
     },
@@ -576,12 +577,13 @@
       }
     },
     "tree-sitter": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.25.0.tgz",
-      "integrity": "sha512-PGZZzFW63eElZJDe/b/R/LbsjDDYJa5UEjLZJB59RQsMX+fo0j54fqBPn1MGKav/QNa0JR0zBiVaikYDWCj5KQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.25.1.tgz",
+      "integrity": "sha512-mrcEdkYtHfrK1A6fs3O6FxkBo0Qig5XUXqHhxUOQu0bmPo00QF4XaSx4edpazdHwxnSCjlGKGgIqWdaN4dvTLA==",
+      "optional": true,
       "peer": true,
       "requires": {
-        "node-addon-api": "^8.3.0",
+        "node-addon-api": "^8.5.0",
         "node-gyp-build": "^4.8.4"
       }
     },


### PR DESCRIPTION
`tree-sitter@0.25.0` ships no prebuilt binaries, so `npm ci` compiles it from source — and its binding includes `node_object_wrap.h`, which does not compile against Node 24's V8 headers. `0.25.1` ships prebuilds for every platform, so nothing gets compiled.

Done with `npm update tree-sitter`, so only `package-lock.json` changes. The `peerDependencies` range stays `^0.25.0` — consumers keep the flexibility, and this only pins what CI and contributors install.

The same command also picked up two entries the lockfile had drifted on:

- the package version, still recorded as 1.6.1
- the `peerDependenciesMeta` key, still the pre-#21 `tree_sitter`

Verified with a clean `npm ci` that 0.25.1 resolves and the test suite passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017dnQ2Nn7CLMP2gEdRhNyt3)_