### PR TITLE
Highlight keywords as constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ now highlighted as functions.
 This is a breaking change for queries that match `(quote ...)` and
 expect it to cover `#'`.
 
+Keywords, such as `:foo`, are now highlighted as constants rather than
+as plain symbols.
+
 # v1.6.1 (released 15 November 2025)
 
 Updated Rust bindings to use tree-sitter-language.

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -73,3 +73,8 @@
   "nil"
   "t"
 ] @constant.builtin
+
+;; Keywords evaluate to themselves, so highlight them as constants too.
+;; https://www.gnu.org/software/emacs/manual/html_node/elisp/Constant-Variables.html
+((symbol) @constant
+  (#match? @constant "^:"))

--- a/test/highlight/keywords.el
+++ b/test/highlight/keywords.el
@@ -1,0 +1,11 @@
+(setq plist '(:foo 1 :bar-baz 2))
+;;              ^ constant
+;;                    ^ constant
+
+(defvar my-var :value)
+;;              ^ constant
+
+(list :a nil t x)
+;;    ^ constant
+;;       ^ constant.builtin
+;;           ^ constant.builtin


### PR DESCRIPTION
Keywords such as `:foo` are extremely common in elisp — plist keys, `defcustom` arguments, `use-package` clauses — but they parse as plain symbols and so got no highlighting at all.

The grammar doesn't give them their own node, so this matches on the symbol text instead:

```scheme
((symbol) @constant
  (#match? @constant "^:"))
```

`@constant` rather than `@keyword`, because elisp keywords are self-evaluating constants, not syntactic keywords — `@keyword` in this file is already used for special forms and `defun`/`defmacro`. It sits alongside the existing `nil`/`t` → `@constant.builtin` rule.

Added `test/highlight/keywords.el`. I checked the assertions actually bite: with the query removed, `tree-sitter test` fails with `expected highlight 'constant', actual highlights: none`.

An alternative would be a `keyword` node in the grammar, which would let queries match structurally instead of by regex — happy to do that instead if you'd prefer, though it's a bigger change and a new node type.

---
_Generated by [Claude Code](https://claude.ai/code/session_017dnQ2Nn7CLMP2gEdRhNyt3)_