### PR TITLE
Require tree-sitter 0.25 for the Python binding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 Homepage = "https://github.com/Wilfred/tree-sitter-elisp"
 
 [project.optional-dependencies]
-core = ["tree-sitter~=0.21"]
+core = ["tree-sitter~=0.25.0"]
 
 [tool.cibuildwheel]
 build = "cp38-*"


### PR DESCRIPTION
The `core` extra was `tree-sitter~=0.21`, which permits 0.21.x. That version's constructor is `Language(path_or_ptr, name)` — two required arguments — so `bindings/python/tests/test_binding.py` raises a `TypeError` on it:

```python
Parser(Language(tree_sitter_elisp.language()))
```

Verified against 0.21.3 in a clean venv.

`~=0.25.0` (rather than `~=0.25`) pins to the 0.25 series and excludes 0.26, matching `package.json`'s `^0.25.0` and `Cargo.toml`'s `0.25.10`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017dnQ2Nn7CLMP2gEdRhNyt3)_