### PR TITLE
Parse infinity and NaN with any mantissa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v1.7.1 (unreleased)
 
+Improved parsing for float literals.
+
 # v1.7.0 (released 29 July 2026)
 
 ## Parsing

--- a/grammar.js
+++ b/grammar.js
@@ -38,8 +38,12 @@ const FLOAT_WITH_DEC_POINT = token(
   seq(/[+-]?[0-9]*\.[0-9]+/, optional(EXPONENT))
 );
 const FLOAT_WITH_EXPONENT = token(seq(/[+-]?[0-9]+\.?[0-9]*/, EXPONENT));
-const FLOAT_INF = token(/[+-]?1\.0[eE]\+INF/);
-const FLOAT_NAN = token(/[+-]?0\.0[eE]\+NaN/);
+// Any mantissa is accepted before e+INF and e+NaN, so 2.0e+INF and
+// 3.0e+NaN are floats too. The exponent sign must be +, and INF and NaN
+// are case sensitive, so 1.0e-INF and 1.0e+inf are symbols.
+const INF_NAN_MANTISSA = /[+-]?([0-9]+\.?[0-9]*|\.[0-9]+)/;
+const FLOAT_INF = token(seq(INF_NAN_MANTISSA, /[eE]\+INF/));
+const FLOAT_NAN = token(seq(INF_NAN_MANTISSA, /[eE]\+NaN/));
 
 // Any character literal may be prefixed by modifiers, e.g. ?\C-, ?\M-
 // or the equivalent ?\^. This includes the escape sequences below, so

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -407,15 +407,33 @@
         {
           "type": "TOKEN",
           "content": {
-            "type": "PATTERN",
-            "value": "[+-]?1\\.0[eE]\\+INF"
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "[+-]?([0-9]+\\.?[0-9]*|\\.[0-9]+)"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[eE]\\+INF"
+              }
+            ]
           }
         },
         {
           "type": "TOKEN",
           "content": {
-            "type": "PATTERN",
-            "value": "[+-]?0\\.0[eE]\\+NaN"
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "[+-]?([0-9]+\\.?[0-9]*|\\.[0-9]+)"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[eE]\\+NaN"
+              }
+            ]
           }
         }
       ]

--- a/test/corpus/floats.txt
+++ b/test/corpus/floats.txt
@@ -58,14 +58,55 @@ Infinity and NaN literals
   (float))
 
 ================================================================================
+Infinity and NaN literals with any mantissa
+================================================================================
+
+2.0e+INF
+1.5e+INF
+-2.5e+INF
+1e+INF
+.5e+INF
+1.e+INF
+3.0e+NaN
+-2.0e+NaN
+12.34e+NaN
+1e+NaN
+1.0E+INF
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (float)
+  (float)
+  (float)
+  (float)
+  (float)
+  (float)
+  (float)
+  (float)
+  (float)
+  (float)
+  (float))
+
+================================================================================
 Symbols that look like infinity and NaN (regression test)
 ================================================================================
 
 1x0e+INF
 0y0e+NaN
+1.0e+inf
+1.0e+nan
+1.0e-INF
+1.0e+INFX
+e+INF
 
 --------------------------------------------------------------------------------
 
 (source_file
+  (symbol)
+  (symbol)
+  (symbol)
+  (symbol)
+  (symbol)
   (symbol)
   (symbol))


### PR DESCRIPTION
The reader accepts any valid mantissa before `e+INF` and `e+NaN`, so `2.0e+INF` and `3.0e+NaN` are floats. The grammar hardcoded `1.0` and `0.0`, so every other spelling became a symbol. Emacs's own float tests use several, including `1e+INF`, `2.0e+NaN` and `3.0e+NaN`.

The mantissa must still be a valid float, the exponent sign must be `+`, and `INF`/`NaN` remain case sensitive, so `1x0e+INF`, `1.0e+inf` and `1.0e-INF` are still symbols. The existing regression test now covers those.

Found by reading every `.el` file in the Emacs tree and in `Wilfred/.emacs.d` with Emacs itself and comparing the numbers it produces against the parse tree. Across all 3864 files this changes 2 trees: `subr-tests.el` and `floatfns-tests.el`, where 9 symbols become floats.

---
_Generated by [Claude Code](https://claude.ai/code/session_015XFW3cdU9dFVaNuM4vRay6)_