### PR TITLE
Parse a dot before a character literal as a dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Improved parsing for float literals.
 
 Improved parsing for symbols separated by control characters.
 
+Improved parsing for character literals after a dot.
+
 # v1.7.0 (released 29 July 2026)
 
 ## Parsing

--- a/grammar.js
+++ b/grammar.js
@@ -16,8 +16,20 @@ const WHITESPACE = /[\x01-\x20\xA0]/;
 // certainly do.
 //
 // Symbols also cannot start with ?.
+const SYMBOL_FIRST = /[^?#\x01-\x20\xA0()\[\]'`,\\";]/;
+const SYMBOL_REST = /[^#\x01-\x20\xA0()\[\]'`,\\";]/;
+const SYMBOL_TAIL = repeat(choice(SYMBOL_REST, /\\./));
+
+// The reader ends a bare "." as soon as the next character is one of
+// "';([#?`, or whitespace, which is how (a .?b) reads as the pair
+// (a . ?b) rather than as a symbol. All of those are already excluded
+// from symbols except ?, so only a leading dot has to rule it out.
+// A dot elsewhere is an ordinary symbol character, so ..? is a symbol.
 const SYMBOL = token(
-  /([^?#\x01-\x20\xA0()\[\]'`,\\";]|\\.)([^#\x01-\x20\xA0()\[\]'`,\\";]|\\.)*/
+  choice(
+    seq(choice(/[^?#.\x01-\x20\xA0()\[\]'`,\\";]/, /\\./), SYMBOL_TAIL),
+    seq(".", optional(seq(choice(SYMBOL_FIRST, /\\./), SYMBOL_TAIL)))
+  )
 );
 
 const ESCAPED_READER_SYMBOL = token(/\\(`|'|,)/);

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -657,8 +657,94 @@
         {
           "type": "TOKEN",
           "content": {
-            "type": "PATTERN",
-            "value": "([^?#\\x01-\\x20\\xA0()\\[\\]'`,\\\\\";]|\\\\.)([^#\\x01-\\x20\\xA0()\\[\\]'`,\\\\\";]|\\\\.)*"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "[^?#.\\x01-\\x20\\xA0()\\[\\]'`,\\\\\";]"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "\\\\."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "PATTERN",
+                          "value": "[^#\\x01-\\x20\\xA0()\\[\\]'`,\\\\\";]"
+                        },
+                        {
+                          "type": "PATTERN",
+                          "value": "\\\\."
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "."
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "[^?#\\x01-\\x20\\xA0()\\[\\]'`,\\\\\";]"
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              }
+                            ]
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "[^#\\x01-\\x20\\xA0()\\[\\]'`,\\\\\";]"
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\\\."
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         },
         {

--- a/test/corpus/lists.txt
+++ b/test/corpus/lists.txt
@@ -23,3 +23,36 @@ Lists
   (list
     (symbol)
     (symbol)))
+
+================================================================================
+Dotted pairs where the dot is not followed by a space
+================================================================================
+
+(a .?b)
+(a .b)
+(a ..b)
+(a ."s")
+(a .[b])
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (list
+    (symbol)
+    (symbol)
+    (char))
+  (list
+    (symbol)
+    (symbol))
+  (list
+    (symbol)
+    (symbol))
+  (list
+    (symbol)
+    (symbol)
+    (string))
+  (list
+    (symbol)
+    (symbol)
+    (vector
+      (symbol))))


### PR DESCRIPTION
The reader ends a bare `.` as soon as the next character is one of `"';([#?,`, backtick or whitespace, so `(a .?b)` is the pair `(a . ?b)`. Every one of those characters was already excluded from symbols except `?`, so `.?b` was lexed as a single symbol and the character literal was swallowed.

Only a leading dot needs to rule out `?`; a dot elsewhere is an ordinary symbol character, so `..?` and `foo.bar` are still symbols.

`cperl-mode.el` has one instance, `'((?{ .?}) ...)`. That is the only tree that changes across all 3864 files in the Emacs tree and `Wilfred/.emacs.d`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015XFW3cdU9dFVaNuM4vRay6)_