### PR TITLE
Parse dotted list separators explicitly

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -11,7 +11,10 @@ const STRING = token(
 //
 // Symbols also cannot start with ?.
 const SYMBOL = token(
-  /([^?# \n\s\f()\[\]'`,\\";]|\\.)([^# \n\s\f()\[\]'`,\\";]|\\.)*/
+  choice(
+    /([^.?# \n\s\f()\[\]'`,\\";]|\\.)([^# \n\s\f()\[\]'`,\\";]|\\.)*/,
+    /\.([^# \n\s\f()\[\]'`,\\";]|\\.)+/
+  )
 );
 
 const ESCAPED_READER_SYMBOL = token(/\\(`|'|,)/);
@@ -120,7 +123,11 @@ module.exports = grammar({
           "unwind-protect",
           "while"
         ),
-        repeat($._sexp),
+        choice(
+          repeat($._sexp),
+          seq(repeat($._sexp), $.dot, $._sexp),
+          seq(repeat($._sexp), alias($.dot, $.symbol))
+        ),
         ")"
       ),
 
@@ -204,7 +211,16 @@ module.exports = grammar({
     unquote: ($) => seq(",", $._sexp),
 
     dot: ($) => token("."),
-    list: ($) => seq("(", choice(repeat($._sexp)), ")"),
+    list: ($) =>
+      seq(
+        "(",
+        choice(
+          repeat($._sexp),
+          seq(repeat1($._sexp), $.dot, $._sexp),
+          seq(repeat1($._sexp), alias($.dot, $.symbol))
+        ),
+        ")"
+      ),
     vector: ($) => seq("[", repeat($._sexp), "]"),
     bytecode: ($) => seq("#[", repeat($._sexp), "]"),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -175,11 +175,57 @@
           ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_sexp"
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_sexp"
+              }
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_sexp"
+                  }
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "dot"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_sexp"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_sexp"
+                  }
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "dot"
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              ]
+            }
+          ]
         },
         {
           "type": "STRING",
@@ -639,8 +685,17 @@
         {
           "type": "TOKEN",
           "content": {
-            "type": "PATTERN",
-            "value": "([^?# \\n\\s\\f()\\[\\]'`,\\\\\";]|\\\\.)([^# \\n\\s\\f()\\[\\]'`,\\\\\";]|\\\\.)*"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "([^.?# \\n\\s\\f()\\[\\]'`,\\\\\";]|\\\\.)([^# \\n\\s\\f()\\[\\]'`,\\\\\";]|\\\\.)*"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\.([^# \\n\\s\\f()\\[\\]'`,\\\\\";]|\\\\.)+"
+              }
+            ]
           }
         },
         {
@@ -743,6 +798,47 @@
                 "type": "SYMBOL",
                 "name": "_sexp"
               }
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_sexp"
+                  }
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "dot"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_sexp"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_sexp"
+                  }
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "dot"
+                  },
+                  "named": true,
+                  "value": "symbol"
+                }
+              ]
             }
           ]
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -466,6 +466,10 @@
           "named": true
         },
         {
+          "type": "dot",
+          "named": true
+        },
+        {
           "type": "float",
           "named": true
         },
@@ -895,6 +899,10 @@
         },
         {
           "type": "char",
+          "named": true
+        },
+        {
+          "type": "dot",
           "named": true
         },
         {
@@ -1393,6 +1401,10 @@
   {
     "type": "defvar",
     "named": false
+  },
+  {
+    "type": "dot",
+    "named": true
   },
   {
     "type": "function",

--- a/test/corpus/lists.txt
+++ b/test/corpus/lists.txt
@@ -6,6 +6,8 @@ Lists
 (foo (bar))
 (1 2 . nil)
 (foo .)
+(setq . 2)
+`(progn . ,body)
 
 --------------------------------------------------------------------------------
 
@@ -18,8 +20,43 @@ Lists
   (list
     (integer)
     (integer)
-    (symbol)
+    (dot)
     (symbol))
   (list
     (symbol)
-    (symbol)))
+    (symbol))
+  (special_form
+    (dot)
+    (integer))
+  (quote
+    (special_form
+      (dot)
+      (unquote
+        (symbol)))))
+
+================================================================================
+Malformed dotted lists
+================================================================================
+
+(. a)
+(a . b c)
+(a . b . c)
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (list
+    (ERROR
+      (dot))
+    (symbol))
+  (list
+    (symbol)
+    (dot)
+    (symbol)
+    (ERROR))
+  (list
+    (symbol)
+    (dot)
+    (symbol)
+    (ERROR
+      (dot))))


### PR DESCRIPTION
## Summary

Represent dotted-list separators with a dedicated `dot` node and reject malformed dotted lists while preserving valid dotted special forms.

## Root cause

The grammar previously parsed a standalone dot as an ordinary symbol, losing the structural distinction between proper and improper lists and accepting invalid placements.

## Impact

Consumers can reliably identify dotted tails, and malformed dotted lists now produce syntax errors.

## Validation

- Added corpus coverage for valid and malformed dotted lists
- `npm test`
- `cargo test`