### PR TITLE
Parse circular object labels

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -84,6 +84,8 @@ module.exports = grammar({
         $.hash_table,
         $.bytecode,
         $.string_text_properties,
+        $.circular_definition,
+        $.circular_reference,
         $._atom,
         $.quote,
         $.function_quote,
@@ -211,6 +213,9 @@ module.exports = grammar({
     string_text_properties: ($) => seq("#(", $.string, repeat($._sexp), ")"),
 
     hash_table: ($) => seq("#s(hash-table", repeat($._sexp), ")"),
+
+    circular_definition: ($) => seq(token(/#[0-9]+=/), $._sexp),
+    circular_reference: ($) => token(/#[0-9]+#/),
 
     comment: ($) => COMMENT,
   },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -46,6 +46,14 @@
         },
         {
           "type": "SYMBOL",
+          "name": "circular_definition"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "circular_reference"
+        },
+        {
+          "type": "SYMBOL",
           "name": "_atom"
         },
         {
@@ -835,6 +843,29 @@
           "value": ")"
         }
       ]
+    },
+    "circular_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "PATTERN",
+            "value": "#[0-9]+="
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_sexp"
+        }
+      ]
+    },
+    "circular_reference": {
+      "type": "TOKEN",
+      "content": {
+        "type": "PATTERN",
+        "value": "#[0-9]+#"
+      }
     },
     "comment": {
       "type": "TOKEN",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -20,6 +20,14 @@
           "named": true
         },
         {
+          "type": "circular_definition",
+          "named": true
+        },
+        {
+          "type": "circular_reference",
+          "named": true
+        },
+        {
           "type": "float",
           "named": true
         },
@@ -88,6 +96,97 @@
     "fields": {}
   },
   {
+    "type": "circular_definition",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "byte_compiled_file_name",
+          "named": true
+        },
+        {
+          "type": "bytecode",
+          "named": true
+        },
+        {
+          "type": "char",
+          "named": true
+        },
+        {
+          "type": "circular_definition",
+          "named": true
+        },
+        {
+          "type": "circular_reference",
+          "named": true
+        },
+        {
+          "type": "float",
+          "named": true
+        },
+        {
+          "type": "function_definition",
+          "named": true
+        },
+        {
+          "type": "function_quote",
+          "named": true
+        },
+        {
+          "type": "hash_table",
+          "named": true
+        },
+        {
+          "type": "integer",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "macro_definition",
+          "named": true
+        },
+        {
+          "type": "quote",
+          "named": true
+        },
+        {
+          "type": "special_form",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "string_text_properties",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "unquote",
+          "named": true
+        },
+        {
+          "type": "unquote_splice",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "float",
     "named": true,
     "fields": {}
@@ -130,6 +229,14 @@
           },
           {
             "type": "char",
+            "named": true
+          },
+          {
+            "type": "circular_definition",
+            "named": true
+          },
+          {
+            "type": "circular_reference",
             "named": true
           },
           {
@@ -209,6 +316,14 @@
         },
         {
           "type": "char",
+          "named": true
+        },
+        {
+          "type": "circular_definition",
+          "named": true
+        },
+        {
+          "type": "circular_reference",
           "named": true
         },
         {
@@ -295,6 +410,14 @@
           "named": true
         },
         {
+          "type": "circular_definition",
+          "named": true
+        },
+        {
+          "type": "circular_reference",
+          "named": true
+        },
+        {
           "type": "float",
           "named": true
         },
@@ -375,6 +498,14 @@
         },
         {
           "type": "char",
+          "named": true
+        },
+        {
+          "type": "circular_definition",
+          "named": true
+        },
+        {
+          "type": "circular_reference",
           "named": true
         },
         {
@@ -463,6 +594,14 @@
         },
         {
           "type": "char",
+          "named": true
+        },
+        {
+          "type": "circular_definition",
+          "named": true
+        },
+        {
+          "type": "circular_reference",
           "named": true
         },
         {
@@ -569,6 +708,14 @@
             "named": true
           },
           {
+            "type": "circular_definition",
+            "named": true
+          },
+          {
+            "type": "circular_reference",
+            "named": true
+          },
+          {
             "type": "float",
             "named": true
           },
@@ -645,6 +792,14 @@
         },
         {
           "type": "char",
+          "named": true
+        },
+        {
+          "type": "circular_definition",
+          "named": true
+        },
+        {
+          "type": "circular_reference",
           "named": true
         },
         {
@@ -728,6 +883,14 @@
         },
         {
           "type": "char",
+          "named": true
+        },
+        {
+          "type": "circular_definition",
+          "named": true
+        },
+        {
+          "type": "circular_reference",
           "named": true
         },
         {
@@ -815,6 +978,14 @@
           "named": true
         },
         {
+          "type": "circular_definition",
+          "named": true
+        },
+        {
+          "type": "circular_reference",
+          "named": true
+        },
+        {
           "type": "float",
           "named": true
         },
@@ -898,6 +1069,14 @@
           "named": true
         },
         {
+          "type": "circular_definition",
+          "named": true
+        },
+        {
+          "type": "circular_reference",
+          "named": true
+        },
+        {
           "type": "float",
           "named": true
         },
@@ -978,6 +1157,14 @@
         },
         {
           "type": "char",
+          "named": true
+        },
+        {
+          "type": "circular_definition",
+          "named": true
+        },
+        {
+          "type": "circular_reference",
           "named": true
         },
         {
@@ -1069,6 +1256,14 @@
           "named": true
         },
         {
+          "type": "circular_definition",
+          "named": true
+        },
+        {
+          "type": "circular_reference",
+          "named": true
+        },
+        {
           "type": "float",
           "named": true
         },
@@ -1152,6 +1347,14 @@
           "named": true
         },
         {
+          "type": "circular_definition",
+          "named": true
+        },
+        {
+          "type": "circular_reference",
+          "named": true
+        },
+        {
           "type": "float",
           "named": true
         },
@@ -1232,6 +1435,14 @@
         },
         {
           "type": "char",
+          "named": true
+        },
+        {
+          "type": "circular_definition",
+          "named": true
+        },
+        {
+          "type": "circular_reference",
           "named": true
         },
         {
@@ -1360,6 +1571,10 @@
   {
     "type": "catch",
     "named": false
+  },
+  {
+    "type": "circular_reference",
+    "named": true
   },
   {
     "type": "comment",

--- a/test/corpus/circular.txt
+++ b/test/corpus/circular.txt
@@ -1,0 +1,20 @@
+================================================================================
+Circular and shared object read syntax
+================================================================================
+
+#1=(a #1#)
+(#1=(a) b #1#)
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (circular_definition
+    (list
+      (symbol)
+      (circular_reference)))
+  (list
+    (circular_definition
+      (list
+        (symbol)))
+    (symbol)
+    (circular_reference)))


### PR DESCRIPTION
## Summary

Add syntax nodes for circular-object definitions (`#N=`) and references (`#N#`).

## Root cause

The grammar did not implement the Emacs reader's shared/circular object label syntax.

## Impact

Circular and shared list structures now parse without errors and retain their definition/reference structure.

## Validation

- Added corpus coverage for circular definitions and references
- `npm test`
- `cargo test`