### PR TITLE
Parse general record literals

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -82,6 +82,7 @@ module.exports = grammar({
         $.list,
         $.vector,
         $.hash_table,
+        $.record,
         $.bytecode,
         $.string_text_properties,
         $._atom,
@@ -211,6 +212,8 @@ module.exports = grammar({
     string_text_properties: ($) => seq("#(", $.string, repeat($._sexp), ")"),
 
     hash_table: ($) => seq("#s(hash-table", repeat($._sexp), ")"),
+    record: ($) =>
+      seq("#s(", field("type", $.symbol), repeat($._sexp), ")"),
 
     comment: ($) => COMMENT,
   },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -38,6 +38,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "record"
+        },
+        {
+          "type": "SYMBOL",
           "name": "bytecode"
         },
         {
@@ -822,6 +826,34 @@
         {
           "type": "STRING",
           "value": "#s(hash-table"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_sexp"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "record": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "#s("
+        },
+        {
+          "type": "FIELD",
+          "name": "type",
+          "content": {
+            "type": "SYMBOL",
+            "name": "symbol"
+          }
         },
         {
           "type": "REPEAT",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -52,6 +52,10 @@
           "named": true
         },
         {
+          "type": "record",
+          "named": true
+        },
+        {
           "type": "special_form",
           "named": true
         },
@@ -165,6 +169,10 @@
             "named": true
           },
           {
+            "type": "record",
+            "named": true
+          },
+          {
             "type": "special_form",
             "named": true
           },
@@ -241,6 +249,10 @@
         },
         {
           "type": "quote",
+          "named": true
+        },
+        {
+          "type": "record",
           "named": true
         },
         {
@@ -327,6 +339,10 @@
           "named": true
         },
         {
+          "type": "record",
+          "named": true
+        },
+        {
           "type": "special_form",
           "named": true
         },
@@ -407,6 +423,10 @@
         },
         {
           "type": "quote",
+          "named": true
+        },
+        {
+          "type": "record",
           "named": true
         },
         {
@@ -495,6 +515,10 @@
         },
         {
           "type": "quote",
+          "named": true
+        },
+        {
+          "type": "record",
           "named": true
         },
         {
@@ -601,6 +625,10 @@
             "named": true
           },
           {
+            "type": "record",
+            "named": true
+          },
+          {
             "type": "special_form",
             "named": true
           },
@@ -677,6 +705,10 @@
         },
         {
           "type": "quote",
+          "named": true
+        },
+        {
+          "type": "record",
           "named": true
         },
         {
@@ -760,6 +792,108 @@
         },
         {
           "type": "quote",
+          "named": true
+        },
+        {
+          "type": "record",
+          "named": true
+        },
+        {
+          "type": "special_form",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "string_text_properties",
+          "named": true
+        },
+        {
+          "type": "symbol",
+          "named": true
+        },
+        {
+          "type": "unquote",
+          "named": true
+        },
+        {
+          "type": "unquote_splice",
+          "named": true
+        },
+        {
+          "type": "vector",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "record",
+    "named": true,
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "symbol",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "byte_compiled_file_name",
+          "named": true
+        },
+        {
+          "type": "bytecode",
+          "named": true
+        },
+        {
+          "type": "char",
+          "named": true
+        },
+        {
+          "type": "float",
+          "named": true
+        },
+        {
+          "type": "function_definition",
+          "named": true
+        },
+        {
+          "type": "function_quote",
+          "named": true
+        },
+        {
+          "type": "hash_table",
+          "named": true
+        },
+        {
+          "type": "integer",
+          "named": true
+        },
+        {
+          "type": "list",
+          "named": true
+        },
+        {
+          "type": "macro_definition",
+          "named": true
+        },
+        {
+          "type": "quote",
+          "named": true
+        },
+        {
+          "type": "record",
           "named": true
         },
         {
@@ -847,6 +981,10 @@
           "named": true
         },
         {
+          "type": "record",
+          "named": true
+        },
+        {
           "type": "special_form",
           "named": true
         },
@@ -930,6 +1068,10 @@
           "named": true
         },
         {
+          "type": "record",
+          "named": true
+        },
+        {
           "type": "special_form",
           "named": true
         },
@@ -1010,6 +1152,10 @@
         },
         {
           "type": "quote",
+          "named": true
+        },
+        {
+          "type": "record",
           "named": true
         },
         {
@@ -1101,6 +1247,10 @@
           "named": true
         },
         {
+          "type": "record",
+          "named": true
+        },
+        {
           "type": "special_form",
           "named": true
         },
@@ -1181,6 +1331,10 @@
         },
         {
           "type": "quote",
+          "named": true
+        },
+        {
+          "type": "record",
           "named": true
         },
         {
@@ -1267,6 +1421,10 @@
           "named": true
         },
         {
+          "type": "record",
+          "named": true
+        },
+        {
           "type": "special_form",
           "named": true
         },
@@ -1311,6 +1469,10 @@
   },
   {
     "type": "#[",
+    "named": false
+  },
+  {
+    "type": "#s(",
     "named": false
   },
   {

--- a/test/corpus/hash_table.txt
+++ b/test/corpus/hash_table.txt
@@ -9,3 +9,22 @@ Hash table read syntax
 (source_file
   (hash_table
     (integer)))
+
+================================================================================
+Record read syntax
+================================================================================
+
+#s(foo bar)
+#s(widget 1 [2])
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (record
+    (symbol)
+    (symbol))
+  (record
+    (symbol)
+    (integer)
+    (vector
+      (integer))))


### PR DESCRIPTION
## Summary

Parse general `#s(...)` record literals, not only the special hash-table representation.

## Root cause

The grammar modeled `#s` exclusively as hash-table read syntax even though the Emacs reader also uses it for arbitrary record types.

## Impact

Struct and record literals now receive a complete `record` syntax tree instead of errors.

## Validation

- Added corpus cases for general records and nested values
- `npm test`
- `cargo test`