### PR TITLE
Parse NUL bytes in comments

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,7 @@
       "sources": [
         "bindings/node/binding.cc",
         "src/parser.c",
-        # NOTE: if your language has an external scanner, add it here.
+        "src/scanner.c",
       ],
       # Node 24 builds addons against V8 headers that need C++ 20.
       #

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -48,4 +48,17 @@ mod tests {
             .set_language(&super::LANGUAGE.into())
             .expect("Error loading Emacs Lisp parser");
     }
+    #[test]
+    fn test_comment_with_nul_bytes() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading Emacs Lisp parser");
+        let tree = parser.parse(b"; a\0b\nfoo", None).unwrap();
+        assert!(
+            !tree.root_node().has_error(),
+            "{}",
+            tree.root_node().to_sexp()
+        );
+    }
 }

--- a/grammar.js
+++ b/grammar.js
@@ -1,5 +1,3 @@
-const COMMENT = token(/;.*/);
-
 const STRING = token(
   seq('"', repeat(choice(/[^"\\]/, seq("\\", /(.|\n)/))), '"')
 );
@@ -68,6 +66,10 @@ const BYTE_COMPILED_FILE_NAME = token("#$");
 
 module.exports = grammar({
   name: "elisp",
+
+  // Comments use an external scanner because the generated lexer treats NUL
+  // as a sentinel, even when it occurs before the actual end of the input.
+  externals: ($) => [$.comment],
 
   extras: ($) => [/(\s|\f)/, $.comment],
 
@@ -212,6 +214,5 @@ module.exports = grammar({
 
     hash_table: ($) => seq("#s(hash-table", repeat($._sexp), ")"),
 
-    comment: ($) => COMMENT,
   },
 });

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -835,13 +835,6 @@
           "value": ")"
         }
       ]
-    },
-    "comment": {
-      "type": "TOKEN",
-      "content": {
-        "type": "PATTERN",
-        "value": ";.*"
-      }
     }
   },
   "extras": [
@@ -856,7 +849,12 @@
   ],
   "conflicts": [],
   "precedences": [],
-  "externals": [],
+  "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "comment"
+    }
+  ],
   "inline": [],
   "supertypes": [],
   "reserved": {}

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,0 +1,53 @@
+#include "tree_sitter/parser.h"
+
+#include <stdbool.h>
+
+enum TokenType {
+  COMMENT,
+};
+
+void *tree_sitter_elisp_external_scanner_create(void) { return NULL; }
+
+void tree_sitter_elisp_external_scanner_destroy(void *payload) {
+  (void)payload;
+}
+
+unsigned tree_sitter_elisp_external_scanner_serialize(void *payload,
+                                                      char *buffer) {
+  (void)payload;
+  (void)buffer;
+  return 0;
+}
+
+void tree_sitter_elisp_external_scanner_deserialize(void *payload,
+                                                    const char *buffer,
+                                                    unsigned length) {
+  (void)payload;
+  (void)buffer;
+  (void)length;
+}
+
+bool tree_sitter_elisp_external_scanner_scan(void *payload, TSLexer *lexer,
+                                             const bool *valid_symbols) {
+  (void)payload;
+
+  if (!valid_symbols[COMMENT]) {
+    return false;
+  }
+
+  while (lexer->lookahead == ' ' ||
+         (lexer->lookahead >= '\t' && lexer->lookahead <= '\r')) {
+    lexer->advance(lexer, true);
+  }
+
+  if (lexer->lookahead != ';') {
+    return false;
+  }
+
+  do {
+    lexer->advance(lexer, false);
+  } while (!lexer->eof(lexer) && lexer->lookahead != '\n');
+
+  lexer->result_symbol = COMMENT;
+  return true;
+}


### PR DESCRIPTION
## Summary

Extend the external scanner to accept raw NUL bytes inside comments.

## Root cause

Like string contents, generated comment tokenization interpreted an embedded zero byte as EOF and ended the token prematurely.

## Impact

Comments containing binary data no longer split into an error and trailing syntax nodes.

## Validation

- Added byte-level Rust regression coverage
- `npm test`
- `cargo test`