### PR TITLE
Parse raw NUL and newline characters

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,7 @@
       "sources": [
         "bindings/node/binding.cc",
         "src/parser.c",
-        # NOTE: if your language has an external scanner, add it here.
+        "src/scanner.c",
       ],
       # Node 24 builds addons against V8 headers that need C++ 20.
       #

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -48,4 +48,21 @@ mod tests {
             .set_language(&super::LANGUAGE.into())
             .expect("Error loading Emacs Lisp parser");
     }
+    #[test]
+    fn test_raw_nul_and_newline_characters() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading Emacs Lisp parser");
+
+        for code in [b"?\0".as_slice(), b"?\n", b"?\\\0", b"?\\\n"] {
+            let tree = parser.parse(code, None).unwrap();
+            assert!(
+                !tree.root_node().has_error(),
+                "{:?}: {}",
+                code,
+                tree.root_node().to_sexp()
+            );
+        }
+    }
 }

--- a/grammar.js
+++ b/grammar.js
@@ -69,6 +69,10 @@ const BYTE_COMPILED_FILE_NAME = token("#$");
 module.exports = grammar({
   name: "elisp",
 
+  // Raw NUL characters require an external scanner because the generated
+  // lexer uses NUL as an end-of-input sentinel.
+  externals: ($) => [$._raw_char],
+
   extras: ($) => [/(\s|\f)/, $.comment],
 
   rules: {
@@ -172,7 +176,8 @@ module.exports = grammar({
         UPPER_CODE_POINT_CHAR,
         HEX_CHAR,
         OCTAL_CHAR,
-        KEY_CHAR
+        KEY_CHAR,
+        $._raw_char
       ),
     string: ($) => STRING,
     byte_compiled_file_name: ($) => BYTE_COMPILED_FILE_NAME,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -555,6 +555,10 @@
             "type": "PATTERN",
             "value": "\\?(\\\\(([CMSHsA]-)|\\^))+(\\\\.|.)"
           }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_raw_char"
         }
       ]
     },
@@ -856,7 +860,12 @@
   ],
   "conflicts": [],
   "precedences": [],
-  "externals": [],
+  "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "_raw_char"
+    }
+  ],
   "inline": [],
   "supertypes": [],
   "reserved": {}

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,0 +1,59 @@
+#include "tree_sitter/parser.h"
+
+#include <stdbool.h>
+
+enum TokenType {
+  RAW_CHAR,
+};
+
+void *tree_sitter_elisp_external_scanner_create(void) { return NULL; }
+
+void tree_sitter_elisp_external_scanner_destroy(void *payload) {
+  (void)payload;
+}
+
+unsigned tree_sitter_elisp_external_scanner_serialize(void *payload,
+                                                      char *buffer) {
+  (void)payload;
+  (void)buffer;
+  return 0;
+}
+
+void tree_sitter_elisp_external_scanner_deserialize(void *payload,
+                                                    const char *buffer,
+                                                    unsigned length) {
+  (void)payload;
+  (void)buffer;
+  (void)length;
+}
+
+bool tree_sitter_elisp_external_scanner_scan(void *payload, TSLexer *lexer,
+                                             const bool *valid_symbols) {
+  (void)payload;
+
+  if (!valid_symbols[RAW_CHAR]) {
+    return false;
+  }
+
+  while (lexer->lookahead == ' ' ||
+         (lexer->lookahead >= '\t' && lexer->lookahead <= '\r')) {
+    lexer->advance(lexer, true);
+  }
+
+  if (lexer->lookahead != '?') {
+    return false;
+  }
+
+  lexer->advance(lexer, false);
+  if (lexer->lookahead == '\\') {
+    lexer->advance(lexer, false);
+  }
+  if (lexer->eof(lexer) ||
+      (lexer->lookahead != 0 && lexer->lookahead != '\n')) {
+    return false;
+  }
+
+  lexer->advance(lexer, false);
+  lexer->result_symbol = RAW_CHAR;
+  return true;
+}


### PR DESCRIPTION
## Summary

Recognize raw NUL and newline bytes following the character-literal prefix.

## Root cause

The character token was handled entirely by generated lexer rules, which could not represent a raw NUL and did not cover the reader-valid raw newline form.

## Impact

These edge-case character literals now produce character nodes rather than parse errors.

## Validation

- Added byte-level Rust cases for raw NUL and newline characters
- `npm test`
- `cargo test`