### PR TITLE
Parse raw escaped symbol characters

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,7 @@
       "sources": [
         "bindings/node/binding.cc",
         "src/parser.c",
-        # NOTE: if your language has an external scanner, add it here.
+        "src/scanner.c",
       ],
       # Node 24 builds addons against V8 headers that need C++ 20.
       #

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -48,4 +48,26 @@ mod tests {
             .set_language(&super::LANGUAGE.into())
             .expect("Error loading Emacs Lisp parser");
     }
+    #[test]
+    fn test_raw_escaped_symbol_characters() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading Emacs Lisp parser");
+
+        for code in [
+            b"foo\\\0bar".as_slice(),
+            b"foo\\\nbar",
+            b"#:foo\\\0bar",
+            b"#:foo\\\nbar",
+        ] {
+            let tree = parser.parse(code, None).unwrap();
+            assert!(
+                !tree.root_node().has_error(),
+                "{:?}: {}",
+                code,
+                tree.root_node().to_sexp()
+            );
+        }
+    }
 }

--- a/grammar.js
+++ b/grammar.js
@@ -69,6 +69,10 @@ const BYTE_COMPILED_FILE_NAME = token("#$");
 module.exports = grammar({
   name: "elisp",
 
+  // Escaped raw NUL characters require an external scanner because the
+  // generated lexer uses NUL as an end-of-input sentinel.
+  externals: ($) => [$._symbol_with_raw_escape],
+
   extras: ($) => [/(\s|\f)/, $.comment],
 
   rules: {
@@ -190,7 +194,8 @@ module.exports = grammar({
         ESCAPED_READER_SYMBOL,
         SYMBOL,
         INTERNED_EMPTY_STRING,
-        UNINTERNED_SYMBOL
+        UNINTERNED_SYMBOL,
+        $._symbol_with_raw_escape
       ),
 
     quote: ($) => seq(choice("'", "`"), $._sexp),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -656,6 +656,10 @@
             "type": "PATTERN",
             "value": "#:([^# \\n\\s\\f()\\[\\]'`,\\\\\";]|\\\\.)*"
           }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_symbol_with_raw_escape"
         }
       ]
     },
@@ -856,7 +860,12 @@
   ],
   "conflicts": [],
   "precedences": [],
-  "externals": [],
+  "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "_symbol_with_raw_escape"
+    }
+  ],
   "inline": [],
   "supertypes": [],
   "reserved": {}

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,0 +1,92 @@
+#include "tree_sitter/parser.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+enum TokenType {
+  SYMBOL_WITH_RAW_ESCAPE,
+};
+
+void *tree_sitter_elisp_external_scanner_create(void) { return NULL; }
+
+void tree_sitter_elisp_external_scanner_destroy(void *payload) {
+  (void)payload;
+}
+
+unsigned tree_sitter_elisp_external_scanner_serialize(void *payload,
+                                                      char *buffer) {
+  (void)payload;
+  (void)buffer;
+  return 0;
+}
+
+void tree_sitter_elisp_external_scanner_deserialize(void *payload,
+                                                    const char *buffer,
+                                                    unsigned length) {
+  (void)payload;
+  (void)buffer;
+  (void)length;
+}
+
+static bool is_symbol_delimiter(int32_t character, bool initial) {
+  return character == 0 || character == ' ' ||
+         (character >= '\t' && character <= '\r') || character == '(' ||
+         character == ')' || character == '[' || character == ']' ||
+         character == '\'' || character == '`' || character == ',' ||
+         character == '"' || character == ';' || character == '#' ||
+         (initial && character == '?');
+}
+
+static bool scan_symbol_with_raw_escape(TSLexer *lexer, bool initial) {
+  bool has_raw_escape = false;
+
+  while (!lexer->eof(lexer)) {
+    if (lexer->lookahead == '\\') {
+      lexer->advance(lexer, false);
+      if (lexer->eof(lexer)) {
+        return false;
+      }
+      has_raw_escape =
+          has_raw_escape || lexer->lookahead == 0 || lexer->lookahead == '\n';
+      lexer->advance(lexer, false);
+      initial = false;
+    } else if (!is_symbol_delimiter(lexer->lookahead, initial)) {
+      lexer->advance(lexer, false);
+      initial = false;
+    } else {
+      break;
+    }
+  }
+
+  if (!has_raw_escape) {
+    return false;
+  }
+
+  lexer->result_symbol = SYMBOL_WITH_RAW_ESCAPE;
+  return true;
+}
+
+bool tree_sitter_elisp_external_scanner_scan(void *payload, TSLexer *lexer,
+                                             const bool *valid_symbols) {
+  (void)payload;
+
+  if (!valid_symbols[SYMBOL_WITH_RAW_ESCAPE]) {
+    return false;
+  }
+
+  while (lexer->lookahead == ' ' ||
+         (lexer->lookahead >= '\t' && lexer->lookahead <= '\r')) {
+    lexer->advance(lexer, true);
+  }
+
+  if (lexer->lookahead == '#') {
+    lexer->advance(lexer, false);
+    if (lexer->lookahead != ':') {
+      return false;
+    }
+    lexer->advance(lexer, false);
+    return scan_symbol_with_raw_escape(lexer, false);
+  }
+
+  return scan_symbol_with_raw_escape(lexer, true);
+}


### PR DESCRIPTION
## Summary

Allow escaped raw NUL and newline bytes within symbols.

## Root cause

The generated escaped-symbol rule could not consume the NUL sentinel and omitted raw-newline handling.

## Impact

Reader-valid symbols containing these escaped bytes now parse as a single symbol node.

## Validation

- Added byte-level Rust regression cases
- `npm test`
- `cargo test`