### PR TITLE
Remove remaining Python binding reference

### DIFF
--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -34,7 +34,6 @@
     "c": false,
     "go": false,
     "node": true,
-    "python": false,
     "rust": true,
     "swift": false,
     "zig": false


### PR DESCRIPTION
## Summary

Remove the remaining `"python": false` binding entry from `tree-sitter.json`.

## Why

Current `main` already removed the Python binding implementation and packaging files, but retained this final Python-specific configuration reference.

## Impact

The repository no longer contains any references to Python or its removed binding.

## Validation

- Searched the repository for Python, `pyproject.toml`, `setup.py`, cibuildwheel, and PyPI references
- Validated `tree-sitter.json` as JSON