### PR TITLE
Fix and extend the highlighting queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # v1.7.3 (unreleased)
 
+## Highlighting
+
+Docstrings are now highlighted as `string.documentation` rather than
+as plain strings.
+
+Argument list markers, such as `&optional` and `&rest`, are now
+highlighted as keywords rather than as parameters.
+
+Variables defined by `defvar` and `defconst`, or bound by `let` and
+`let*`, are now highlighted, as are `#(` and `#$`.
+
 # v1.7.2 (released 30 July 2026)
 
 Improved parsing for float literals.

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,3 +1,6 @@
+;; When several patterns capture the same node, the last one wins, so
+;; a pattern that refines another must come after it.
+
 ;; Special forms
 [
   "and"
@@ -33,28 +36,82 @@
  ] @keyword
 (function_definition name: (symbol) @function)
 (function_definition parameters: (list (symbol) @variable.parameter))
-(function_definition docstring: (string) @comment)
 
 ;; Highlight macro definitions the same way as function definitions.
 "defmacro" @keyword
 (macro_definition name: (symbol) @function)
 (macro_definition parameters: (list (symbol) @variable.parameter))
-(macro_definition docstring: (string) @comment)
+
+;; &optional and &rest are argument list markers, not parameters.
+;; https://www.gnu.org/software/emacs/manual/html_node/elisp/Argument-List.html
+(function_definition
+  parameters: (list (symbol) @keyword
+    (#match? @keyword "^&")))
+(macro_definition
+  parameters: (list (symbol) @keyword
+    (#match? @keyword "^&")))
 
 ;; A sharp quoted symbol is a function reference, e.g. #'foo.
 (function_quote (symbol) @function)
+
+;; The variable defined by defvar or defconst. The anchor restricts
+;; this to the first symbol, leaving the initial value alone.
+(special_form
+  [
+    "defconst"
+    "defvar"
+  ]
+  .
+  (symbol) @variable)
+
+;; Variables bound by let and let*, written either as (let ((x 1)))
+;; or as (let (x)).
+(special_form
+  [
+    "let"
+    "let*"
+  ]
+  .
+  (list
+    [
+      (symbol) @variable
+      (list . (symbol) @variable)
+    ]))
 
 (comment) @comment
 
 (integer) @number
 (float) @number
+;; Characters are integers in Emacs Lisp, e.g. ?a is 97.
 (char) @number
 
 (string) @string
 
+;; Docstrings are strings too, so these come after (string) @string.
+(function_definition docstring: (string) @string.documentation)
+(macro_definition docstring: (string) @string.documentation)
+;; defvar and defconst take the docstring after the initial value, so
+;; (defvar foo nil "Doc.") has one but (defvar foo "Value") does not.
+(special_form
+  [
+    "defconst"
+    "defvar"
+  ]
+  .
+  (symbol)
+  .
+  (_)
+  .
+  (string) @string.documentation)
+
+;; #$ is the name of the file being loaded.
+;; https://www.gnu.org/software/emacs/manual/html_node/elisp/Special-Read-Syntax.html
+(byte_compiled_file_name) @constant.builtin
+
 [
   "("
   ")"
+  "#("
   "#["
   "["
   "]"

--- a/test/highlight/functions.el
+++ b/test/highlight/functions.el
@@ -1,10 +1,27 @@
 (defun foo (x)
-  ;; ^ keyword
+;;^ keyword
   ;;   ^ function
   ;;        ^ variable.parameter
   "stuff"
-  ;; ^ string
+;; ^ string.documentation
   x)
+
+(defun bar (x &optional y &rest zs)
+  ;;          ^ keyword
+  ;;                    ^ variable.parameter
+  ;;                      ^ keyword
+  ;;                            ^ variable.parameter
+  (list x y zs))
+
+(defmacro baz (a &rest body)
+  ;;^ keyword
+  ;;      ^ function
+  ;;           ^ variable.parameter
+  ;;             ^ keyword
+  ;;                   ^ variable.parameter
+  "Docstring."
+;; ^ string.documentation
+  body)
 
 (mapcar #'foo xs)
 ;;      ^ operator

--- a/test/highlight/literals.el
+++ b/test/highlight/literals.el
@@ -1,0 +1,29 @@
+(list 1 2.5 ?a "text")
+;;    ^ number
+;;      ^ number
+;;          ^ number
+;;              ^ string
+
+(list ?\C-x ?\N{LATIN SMALL LETTER A})
+;;    ^ number
+;;          ^ number
+
+(vconcat [1 2] "x")
+;;       ^ punctuation.bracket
+;;           ^ punctuation.bracket
+
+(list #[1 2])
+;;    ^ punctuation.bracket
+
+(list #("text" 0 4 (face bold)))
+;;    ^ punctuation.bracket
+
+;; #$ is the name of the file being loaded.
+(list #$)
+;;    ^ constant.builtin
+
+(list `(a ,b ,@c) 'd)
+;;    ^ operator
+;;        ^ operator
+;;           ^ operator
+;;                ^ operator

--- a/test/highlight/variables.el
+++ b/test/highlight/variables.el
@@ -1,0 +1,25 @@
+(defvar my-var nil "Docstring.")
+;;      ^ variable
+;;             ^ constant.builtin
+;;                  ^ string.documentation
+
+(defconst my-const 1 "Docstring.")
+;;        ^ variable
+;;                 ^ number
+;;                    ^ string.documentation
+
+;; The second argument is the initial value, not a docstring.
+(defvar other-var "Not a docstring.")
+;;      ^ variable
+;;                 ^ string
+
+(let ((x 1)
+;;     ^ variable
+      (y 2))
+;;     ^ variable
+  (+ x y))
+
+(let* (a (b 3))
+;;     ^ variable
+;;        ^ variable
+  (list a b))


### PR DESCRIPTION
The docstring rules had no effect. Tree-sitter applies the last pattern that captures a node, so `(string) @string` overrode them. They now come after that rule and capture `string.documentation`, which falls back to `string` in themes that don't distinguish docstrings.

Argument list markers such as `&optional` and `&rest` were highlighted as parameters, as they are symbols in the parameter list. They are highlighted as keywords now.

The variable defined by `defvar` and `defconst`, the variables bound by `let` and `let*`, the `#(` bracket and `#$` are also highlighted now. The patterns are anchored, so a `defvar` initial value or a `let` body is left alone:

| Input | Highlighted |
|---|---|
| `(defvar foo bar)` | `foo` only |
| `(defvar foo nil "Doc.")` | `foo`, `nil`, and the docstring |
| `(let ((a 1) b) (fn a))` | `a` and `b` only |

The highlight tests have grown from 12 assertions to 49, covering every rule that changed.

https://claude.ai/code/session_01RcY6VoYzpA9vpjtVKyNoQj