### PR TITLE
Sync the lock file version with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-elisp",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-elisp",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Rolling the version in d7f9ae2 updated `package.json` to 1.7.3 but left `package-lock.json` at 1.7.2, so `npm install` rewrites the lock file on a clean checkout.

Only the two root `version` fields change. `lockfileVersion` stays at 2, as regenerating the file would migrate it to the current format.

https://claude.ai/code/session_01RcY6VoYzpA9vpjtVKyNoQj